### PR TITLE
feat: 🎸 allow secrets manager modules

### DIFF
--- a/allowlist/modules.rego
+++ b/allowlist/modules.rego
@@ -26,4 +26,10 @@ allowed_modules contains m if {
 	regex.match(`^module\..*\.module\.iam_assumable_role\.aws_iam_role\.this\[0\]$`, m.address)
 }
 
+allowed_modules contains m if {
+	m := tfplan.resource_changes[_]
+	m.change.actions[_] != "no-op"
+	regex.match(`^module\..*\.kubernetes_manifest.secret_store$`, m.address)
+}
+
 allowed_modules_addrs := {arr | arr := allowed_modules[_].module_address}


### PR DESCRIPTION
- allow secrets manager modules to be auto-approved
- there isn't much to break here so it's very simple to add to the allowlist