### PR TITLE
fix: 🐛 irsa submodule calls are valid

### DIFF
--- a/irsa/tests/fixtures/changes.rego
+++ b/irsa/tests/fixtures/changes.rego
@@ -1025,3 +1025,46 @@ irsa_mismatch_create_mock_tfplan := {"resource_changes": [
 		},
 	},
 ]}
+
+submodule_irsa := {"resource_changes": [{
+	"address": "module.secrets_manager.module.irsa.kubernetes_service_account.generated_sa",
+	"module_address": "module.secrets_manager.module.irsa",
+	"mode": "managed",
+	"type": "kubernetes_service_account",
+	"name": "generated_sa",
+	"provider_name": "registry.terraform.io/hashicorp/kubernetes",
+	"change": {
+		"actions": ["create"],
+		"before": null,
+		"after": {
+			"automount_service_account_token": true,
+			"image_pull_secret": [],
+			"metadata": [{
+				"generate_name": null,
+				"labels": null,
+				"namespace": "jaskaran-dev",
+			}],
+			"secret": [],
+			"timeouts": null,
+		},
+		"after_unknown": {
+			"default_secret_name": true,
+			"id": true,
+			"image_pull_secret": [],
+			"metadata": [{
+				"annotations": true,
+				"generation": true,
+				"name": true,
+				"resource_version": true,
+				"uid": true,
+			}],
+			"secret": [],
+		},
+		"before_sensitive": false,
+		"after_sensitive": {
+			"image_pull_secret": [],
+			"metadata": [{"annotations": {}}],
+			"secret": [],
+		},
+	},
+}]}

--- a/irsa/tests/main_test.rego
+++ b/irsa/tests/main_test.rego
@@ -90,3 +90,13 @@ test_allow_hard_coded_correct_ns if {
 	result.valid
 	result.msg == "Valid irsa related terraform changes"
 }
+
+test_allow_irsa_if_called_by_another_module if {
+	result := analysis.allow with input as {
+		"variables": {"namespace": {"value": "testing-ns"}},
+		"resource_changes": submodule_irsa.resource_changes,
+		"configuration": {"root_module": {"module_calls": {"ap_irsa": {"expressions": {"namespace": {"constant_value": "testing-ns"}, "role_policy_arns": {"references": ["var.foobar"]}}}}}},
+	}
+	result.valid
+	result.msg == "Valid irsa related terraform changes"
+}


### PR DESCRIPTION
- if irsa is a child module of another module then approve (the other module will be checked independently)