### PR TITLE
fix: 🐛 allow if shares allowed module_address

### DIFF
--- a/allowlist/modules.rego
+++ b/allowlist/modules.rego
@@ -4,43 +4,36 @@ import input as tfplan
 
 allowed_modules contains m if {
 	m := tfplan.resource_changes[_]
-	m.change.actions[_] != "no-op"
 	regex.match(`^module\..*\.kubernetes_deployment\.service_pod$`, m.address)
 }
 
 allowed_modules contains m if {
 	m := tfplan.resource_changes[_]
-	m.change.actions[_] != "no-op"
 	m.type == `aws_ecr_repository`
 }
 
 allowed_modules contains m if {
 	m := tfplan.resource_changes[_]
-	m.change.actions[_] != "no-op"
 	regex.match(`^module\..*\.kubernetes_service_account\.generated_sa$`, m.address)
 }
 
 allowed_modules contains m if {
 	m := tfplan.resource_changes[_]
-	m.change.actions[_] != "no-op"
 	regex.match(`^module\..*\.module\.iam_assumable_role\.aws_iam_role\.this\[0\]$`, m.address)
 }
 
 allowed_modules contains m if {
 	m := tfplan.resource_changes[_]
-	m.change.actions[_] != "no-op"
 	regex.match(`^module\..*\.aws_secretsmanager_secret.secret.*$`, m.address)
 }
 
 allowed_modules contains m if {
 	m := tfplan.resource_changes[_]
-	m.change.actions[_] != "no-op"
 	regex.match(`^module\..*\.module.service_account.kubernetes_role.github_actions_role$`, m.address)
 }
 
 allowed_modules contains m if {
 	m := tfplan.resource_changes[_]
-	m.change.actions[_] != "no-op"
 	regex.match(`^module\..*\.aws_sns_topic.new_topic$`, m.address)
 }
 

--- a/allowlist/tests/ecr_test.rego
+++ b/allowlist/tests/ecr_test.rego
@@ -3,7 +3,7 @@ package test.terraform.analysis
 import data.terraform.analysis
 
 test_deny_only_noop_ecr if {
-	modified_plan := {
+	modified_plan := [{
 		"address": "module.ecr.foobar",
 		"module_address": "module.ecr",
 		"type": "aws_ecr_repository",
@@ -12,9 +12,19 @@ test_deny_only_noop_ecr if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
+{
+		"address": "module.fake.foobar",
+		"module_address": "module.fake",
+		"type": "aws_ecr_fake",
+		"change": {
+			"actions": ["create"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	}]
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }

--- a/allowlist/tests/hmpps_template_test.rego
+++ b/allowlist/tests/hmpps_template_test.rego
@@ -3,7 +3,7 @@ package test.terraform.analysis
 import data.terraform.analysis
 
 test_deny_only_noop_hmpps if {
-	modified_plan := {
+	modified_plan := [{
 		"address": "module.foobar.module.service_account.kubernetes_role.github_actions_role",
 		"module_address": "module.foobar.module.service_account",
 		"change": {
@@ -11,9 +11,18 @@ test_deny_only_noop_hmpps if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
+{
+		"address": "module.fake.module.service_account.kubernetes_role.github_actions_fake",
+		"module_address": "module.fake.module.service_account",
+		"change": {
+			"actions": ["create"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	}]
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }

--- a/allowlist/tests/irsa_test.rego
+++ b/allowlist/tests/irsa_test.rego
@@ -4,6 +4,18 @@ import data.terraform.analysis
 
 test_deny_only_noop_irsa if {
 	modified_plan := [
+{
+			"address": "module.ap_irsa.kubernetes_service_account.fake",
+			"module_address": "module.irsa_fake",
+			"mode": "managed",
+			"type": "kubernetes_service_account",
+			"name": "generated_sa",
+			"provider_name": "registry.terraform.io/hashicorp/kubernetes",
+			"change": {
+				"actions": ["create"],
+				"before": null,
+			},
+		},
 		{
 			"address": "module.ap_irsa.kubernetes_service_account.generated_sa",
 			"module_address": "module.ap_irsa",

--- a/allowlist/tests/kubernetes_secrets_test.rego
+++ b/allowlist/tests/kubernetes_secrets_test.rego
@@ -3,7 +3,7 @@ package test.terraform.analysis
 import data.terraform.analysis
 
 test_deny_only_noop_kubernetes_secret if {
-	modified_plan := {
+	modified_plan := [{
 		"address": "kubernetes_secret.test",
 		"type": "kubernetes_secret",
 		"change": {
@@ -11,9 +11,18 @@ test_deny_only_noop_kubernetes_secret if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
+{
+		"address": "kubernetes_secret_fake.test",
+		"type": "kubernetes_fake",
+		"change": {
+			"actions": ["create"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	}]
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }

--- a/allowlist/tests/main_test.rego
+++ b/allowlist/tests/main_test.rego
@@ -3,7 +3,7 @@ package test.terraform.analysis
 import data.terraform.analysis
 
 test_deny_no_module if {
-	res := analysis.allow with input as {"resource_changes": [mock_tfplan.resource_changes]}
+	res := analysis.allow with input as {"resource_changes": mock_tfplan.resource_changes}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }

--- a/allowlist/tests/pingdom_check_test.rego
+++ b/allowlist/tests/pingdom_check_test.rego
@@ -3,7 +3,7 @@ package test.terraform.analysis
 import data.terraform.analysis
 
 test_deny_only_noop_pingdom_check if {
-	modified_plan := {
+	modified_plan := [{
 		"address": "pingdom_check.test",
 		"type": "pingdom_check",
 		"change": {
@@ -11,9 +11,18 @@ test_deny_only_noop_pingdom_check if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
+{
+		"address": "pingdom_fake.test",
+		"type": "pingdom_fake",
+		"change": {
+			"actions": ["update"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	}]
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }

--- a/allowlist/tests/secrets_manager_test.rego
+++ b/allowlist/tests/secrets_manager_test.rego
@@ -3,7 +3,7 @@ package test.terraform.analysis
 import data.terraform.analysis
 
 test_deny_only_noop_sm if {
-	modified_plan := {
+	modified_plan := [{
 		"address": "module.foobar.aws_secretsmanager_secret.secret[\"random\"]",
 		"module_address": "module.foobar",
 		"change": {
@@ -11,9 +11,18 @@ test_deny_only_noop_sm if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
+{
+		"address": "module.fake.aws_secretsmanager_fake",
+		"module_address": "module.fake",
+		"change": {
+			"actions": ["update"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	}]
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }

--- a/allowlist/tests/service_pod_test.rego
+++ b/allowlist/tests/service_pod_test.rego
@@ -3,7 +3,7 @@ package test.terraform.analysis
 import data.terraform.analysis
 
 test_deny_only_noop_service_pod if {
-	modified_plan := {
+	modified_plan := [{
 		"address": "module.sp.kubernetes_deployment.service_pod",
 		"module_address": "module.sp",
 		"change": {
@@ -11,9 +11,18 @@ test_deny_only_noop_service_pod if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
+{
+		"address": "module.fake.kubernetes_deployment.service_fake",
+		"module_address": "module.fake",
+		"change": {
+			"actions": ["create"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	}]
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }

--- a/allowlist/tests/sns_test.rego
+++ b/allowlist/tests/sns_test.rego
@@ -2,8 +2,9 @@ package test.terraform.analysis
 
 import data.terraform.analysis
 
-test_deny_only_noop_sm if {
-	modified_plan := {
+test_deny_only_noop_sns if {
+	modified_plan := [
+	{
 		"address": "module.foobar.aws_sns_topic.new_topic",
 		"module_address": "module.foobar",
 		"change": {
@@ -11,14 +12,24 @@ test_deny_only_noop_sm if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
+	{
+		"address": "module.barbuzz.fake_topic",
+		"module_address": "module.barbuzz",
+		"change": {
+			"actions": ["update"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	},
+	]
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }
 
-test_allow_sm if {
+test_allow_sns if {
 	modified_plan := {
 		"address": "module.foobar.aws_sns_topic.new_topic",
 		"module_address": "module.foobar",
@@ -35,7 +46,7 @@ test_allow_sm if {
 }
 
 test_deny_only_noop_sns_sub if {
-	modified_plan := {
+	modified_plan := [{
 		"address": "module.foobar.aws_sns_topic.new_topic",
 		"type": "aws_sns_topic_subscription",
 		"change": {
@@ -43,9 +54,19 @@ test_deny_only_noop_sns_sub if {
 			"before": {"name": "jazz-test"},
 			"after": {"name": "jazz-test"},
 		},
-	}
+	},
 
-	res := analysis.allow with input as {"resource_changes": [modified_plan]}
+	{
+		"address": "module.barbuzz.fake_topic",
+		"module_address": "module.barbuzz",
+		"change": {
+			"actions": ["update"],
+			"before": {"name": "jazz-test"},
+			"after": {"name": "jazz-test"},
+		},
+	},]
+
+	res := analysis.allow with input as {"resource_changes": modified_plan}
 	not res.valid
 	res.msg == "This PR includes changes to modules / resources which are not on the allowlist, so we can't auto approve these changes. Please request a Cloud Platform team member's review in [#ask-cloud-platform](https://moj.enterprise.slack.com/archives/C57UPMZLY)"
 }


### PR DESCRIPTION
this pr was failing the allowlist check even though it was on the allowlist. This is because the allowlist was too restrictive. any resource which shares the module_address as the specified resource in the allowlist should be marked for auto-approval

- correct boolean logic and add default values for vars
- invert I am logic to force false value
- fix tests (noop fails if it is smuggling an invalid module)